### PR TITLE
PCIe Lane Swap Fix

### DIFF
--- a/peripherals/hmcad1520_adc.py
+++ b/peripherals/hmcad1520_adc.py
@@ -424,7 +424,7 @@ class HMCAD1520ADC(LiteXModule):
                 ]
                 gearbox_cases[2] = [
                     adc_source.data[((16*i)):(16*(i+1)-4)].eq(d12_gear.source.data),
-                    {adc_source.data[16*(i+1)-4+j].eq(0) for j in range(4)},
+                    {adc_source.data[16*(i+1)-j].eq(d12_gear.source.data[11]) for j in range(1,5)},
                     adc_source.valid.eq(d12_gear.source.valid)
                 ]
 

--- a/thunderscope_platform.py
+++ b/thunderscope_platform.py
@@ -215,10 +215,10 @@ a7_thunderscope_rev5 = [
         Subsignal("rst_n", Pins("U9"), IOStandard("LVCMOS33"), Misc("PULLUP=TRUE")),
         Subsignal("clk_p", Pins("B6")),
         Subsignal("clk_n", Pins("B5")),
-        Subsignal("rx_p",  Pins("E4 A4 C4 G4")),
-        Subsignal("rx_n",  Pins("E3 A3 C3 G3")),
-        Subsignal("tx_p",  Pins("H2 F2 D2 B2")),
-        Subsignal("tx_n",  Pins("H1 F1 D1 B1")),
+        Subsignal("rx_p",  Pins("G4 C4 A4 E4")),
+        Subsignal("rx_n",  Pins("G3 C3 A3 E3")),
+        Subsignal("tx_p",  Pins("B2 D2 F2 H2")),
+        Subsignal("tx_n",  Pins("B1 D1 F1 H1")),
     ),
 
     # Frontend.


### PR DESCRIPTION
Swap the lanes of the PCIe PHY to match the order at the slot.

Fix sign-extend with the LSB-justified 12-bit samples.